### PR TITLE
Makes aggregation time a rogue variable

### DIFF
--- a/include/SmurfBuilder.h
+++ b/include/SmurfBuilder.h
@@ -25,6 +25,9 @@ public:
     static void setup_python();
 
     float agg_duration_; // Aggregation duration in seconds
+    void SetAggDuration(float dur){ agg_duration_ = dur;};
+    const float GetAggDuration(){ return agg_duration_; };
+
 
 protected:
     void ProcessNewData();
@@ -36,9 +39,10 @@ private:
 
     uint16_t num_channels_;
 
-
     // Puts all stashed data in G3Frame and sends it out.
     void FlushReadStash();
+
+    // safely swaps read and write stashes
     void SwapStash();
 
     // Calls FlushStash every agg_duration_ seconds

--- a/python/sosmurf/SessionManager.py
+++ b/python/sosmurf/SessionManager.py
@@ -3,7 +3,7 @@ import yaml
 import time
 from enum import Enum
 
-class FlowControl:
+class FlowControl(Enum):
     """Flow control enumeration."""
     ALIVE = 0
     START = 1
@@ -31,7 +31,7 @@ class SessionManager:
                 flow control type
         """
         frame = core.G3Frame(core.G3FrameType.none)
-        frame['sostream_flowcontrol'] = fc
+        frame['sostream_flowcontrol'] = fc.value
         return frame
 
     def status_frame(self):
@@ -66,11 +66,11 @@ class SessionManager:
                 out.append(self.flowcontrol_frame(FlowControl.END))
 
                 f = core.G3Frame(core.G3FrameType.Observation)
-                f['sostream_flowcontrol'] = FlowControl.CLEANSE
+                f['sostream_flowcontrol'] = FlowControl.CLEANSE.value
                 out.append(f)
 
                 f = core.G3Frame(core.G3FrameType.Wiring)
-                f['sostream_flowcontrol'] = FlowControl.CLEANSE
+                f['sostream_flowcontrol'] = FlowControl.CLEANSE.value
                 out.append(f)
 
                 self.session_id = None

--- a/python/sosmurf/StreamBase/_StreamBase.py
+++ b/python/sosmurf/StreamBase/_StreamBase.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+
+import pyrogue
+import smurf
+import sosmurfcore
+
+class StreamBase(pyrogue.Device):
+    """
+        Stream Base pyrogue object.
+    """
+    def __init__(self, name, debug_data=False, debug_meta=False, agg_time=1.0, **kwargs):
+        pyrogue.Device.__init__(self, name=name, description='SMuRF Data CustomTransmitter', **kwargs)
+
+        self.builder = sosmurfcore.SmurfBuilder()
+        self._transmitter = sosmurfcore.SmurfTransmitter(self.builder, debug_data, debug_meta)
+
+        # Add pyrogue variables here!!
+        self.add(pyrogue.LocalVariable(
+            name='DebugData',
+            description='Set the debug mode, for the data',
+            mode='RW',
+            value=debug_data,
+            localSet=lambda value: self._transmitter.setDebugData(value),
+            localGet=self._transmitter.getDebugData))
+
+        # Add a variable for the debugMeta flag
+        self.add(pyrogue.LocalVariable(
+            name='DebugMeta',
+            description='Set the debug mode, for the metadata',
+            mode='RW',
+            value=debug_meta,
+            localSet=lambda value: self._transmitter.setDebugMeta(value),
+            localGet=self._transmitter.getDebugMeta))
+
+        self.add(pyrogue.LocalVariable(
+            name='AggTime',
+            description='Sets the time [sec] for which the builder will listen '
+                        'for samples before publishing to a G3Frame',
+            mode='RW',
+            value=float(agg_time),
+            localSet=lambda value: self.builder.SetAggDuration(value),
+            localGet=self.builder.GetAggDuration))
+
+
+    def getDataChannel(self):
+        return self._transmitter.getDataChannel()
+
+    def getMetaChannel(self):
+        return self._transmitter.getMetaChannel()

--- a/python/sosmurf/StreamBase/__init__.py
+++ b/python/sosmurf/StreamBase/__init__.py
@@ -1,0 +1,1 @@
+from sosmurf.StreamBase._StreamBase import StreamBase

--- a/python/sosmurf/__init__.py
+++ b/python/sosmurf/__init__.py
@@ -2,6 +2,4 @@ import sosmurf.util
 import sosmurf.SessionManager
 
 from sosmurf.SmurfTransmitter import SmurfTransmitter
-
-# Doesn't need a rogue wrapper yet, but maybe we want that eventually.
-from sosmurfcore import SmurfBuilder
+from sosmurf.StreamBase import StreamBase

--- a/scripts/emulate.py
+++ b/scripts/emulate.py
@@ -22,14 +22,10 @@ def main():
     args = parser.parse_args()
     pysmurf_common.process_args(args)
 
-
-    builder = sosmurf.SmurfBuilder()
-    transmitter = sosmurf.SmurfTransmitter(
-        builder, name="SOSmurfTransmitter", debug_meta=True, debug_data=False
-    )
+    stream_root = sosmurf.StreamBase("SOStream", debug_meta=False, debug_data=False, agg_time=1.0)
 
     pipe = core.G3Pipeline()
-    pipe.Add(builder)
+    pipe.Add(stream_root.builder)
     pipe.Add(sosmurf.SessionManager.SessionManager, stream_id=args.stream_id)
     pipe.Add(sosmurf.util.stream_dumper)
     pipe.Add(core.G3NetworkSender, hostname='*', port=args.stream_port,
@@ -50,9 +46,10 @@ def main():
                          pv_dump_file   = args.pv_dump_file,
                          disable_bay0   = args.disable_bay0,
                          disable_bay1   = args.disable_bay1,
-                         txDevice       = transmitter,
+                         txDevice       = stream_root,
                          VariableGroups = vgs) as root:
         print("Loaded Emulation root", flush=True)
+
 
         # Add dummy TES bias values ([-8:7]), for testing purposes.
         for i in range(16):

--- a/src/SmurfBuilder.cpp
+++ b/src/SmurfBuilder.cpp
@@ -166,6 +166,8 @@ void SmurfBuilder::setup_python(){
     "Takes transmitted smurf-packets and puts them into G3Frames, starting off "
     "the stream's G3Pipeline ",
     bp::init<>())
+    .def("GetAggDuration", &SmurfBuilder::GetAggDuration)
+    .def("SetAggDuration", &SmurfBuilder::SetAggDuration)
     ;
 
     bp::implicitly_convertible<SmurfBuilderPtr, G3ModulePtr>();

--- a/src/SmurfBuilder.cpp
+++ b/src/SmurfBuilder.cpp
@@ -35,12 +35,20 @@ SmurfBuilder::~SmurfBuilder(){
 
 void SmurfBuilder::ProcessStashThread(SmurfBuilder *builder){
     builder->running_ = true;
+
     while (builder->running_) {
-        std::this_thread::sleep_for(
-            std::chrono::milliseconds(int(1000 * builder->agg_duration_))
-        );
+
+        auto start = std::chrono::system_clock::now();
         builder->SwapStash();
         builder->FlushReadStash();
+        auto end = std::chrono::system_clock::now();
+
+        auto diff = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
+        std::chrono::milliseconds iter_time((int)(1000 * builder->agg_duration_));
+        std::chrono::milliseconds sleep_time = iter_time - diff;
+
+        if (sleep_time.count() > 0)
+            std::this_thread::sleep_for(sleep_time);
     }
 }
 


### PR DESCRIPTION
This PR turns agg_duration, the time that the smurf-builder will wait before converting stash into a G3Frame, into a rogue variable. This way it can be set from the python startup script or using epics.