### PR TITLE
Combines pcie and ethernet into a single streaming script

### DIFF
--- a/python/sosmurf/util.py
+++ b/python/sosmurf/util.py
@@ -5,6 +5,8 @@ import os
 import pyrogue
 import sys
 from spt3g import core
+import yaml
+
 
 class stream_dumper:
     """Simple dump module that ignores flow-control keep_alive frames"""
@@ -23,18 +25,33 @@ class stream_dumper:
 
         print(frame)
 
-def setup_server():
+
+def setup_server(cfg, slot):
     """
         Runs the shell script to setup and configure the smurf server.
         The shell script processes some command line arguments and returns a 
         modified version.
     """
     print("-"*60)
-    print("Running setup_server.sh {}\n".format(' '.join(sys.argv[1:])))
+    # Replaces any of these args with defaults from sys_config
+    pre_parser = argparse.ArgumentParser()
+    pre_parser.add_argument('--shelfmanager', '-S')
+    # pre_parser.add_argument('--slot', '-N')
+    pre_parser.add_argument('--addr', '-a')
+    pre_parser.add_argument('--comm-type', '-c')
+    args, _ = pre_parser.parse_known_args()
+    setup_args = sys.argv[1:]
+
+    if args.addr is None and args.shelfmanager is None:
+        setup_args.extend(['--addr', f'10.0.1.{100+slot}'])
+    if args.comm_type is None:
+        setup_args.extend(['--comm-type', cfg['comm_type']])
+
+    print("Running setup_server.sh {}\n".format(' '.join(setup_args)))
 
     script = '/usr/local/src/smurf-streamer/scripts/setup_server.sh'
     proc = subprocess.run(
-        [script] + sys.argv[1:], 
+        [script] + setup_args,
         stdout=subprocess.PIPE, 
         stderr=subprocess.STDOUT
     )
@@ -56,6 +73,9 @@ def setup_server():
     return args
 
 
+def get_metadata_groups(filename):
+    return {}
+
 def get_kwargs(args, dev_type, **extra_kwargs):
     """
         Returns the kwargs needed to instantiate specific rogue objects.
@@ -68,7 +88,7 @@ def get_kwargs(args, dev_type, **extra_kwargs):
         Any additional keyword arguments will be added to the dict.
     """
     if dev_type=="pcie":
-        kwargs = {   
+        kwargs = {
             'lane': args.pcie_rssi_lane,
             'ip_addr': args.ip_addr,
             'dev_rssi': args.pcie_dev_rssi,
@@ -76,7 +96,7 @@ def get_kwargs(args, dev_type, **extra_kwargs):
         }
 
     elif dev_type=="cmb_pcie":
-         kwargs = {   
+         kwargs = {
             'config_file'   :  args.config_file,
             'epics_prefix'  :  args.epics_prefix,
             'polling_en'    :  args.polling_en,


### PR DESCRIPTION
This PR does a couple of things. The main goal is have a single script to stream data (instead of separate ones for pcie vs ethernet), and to limit the amount of command line args that it requires. The command line args are only set in the docker-compose file and its easy to mess those up. For instance, multiple times I forget to add the disable bay arguments, or forget to change the communication type in the args along with the script I'm running. 

With this, the docker-compose entry can just look like this 
```
stream-streamer-s2:
    <<: *smurf-streamer
    container_name: smurf-streamer-s2
    environment:
        SLOT: 2
```
and the stream script will pull all relevant info from the sys_config file, which should contains stuff like this:
```
crate_id: 1
shelf_manager: shm-smrf-sp01
comm_type: eth
max_fan_level: 10

slots:
    order: [2]
    SLOT[2]:
        stream_port: 4532
        rogue_defaults: /tmp/fw/smurf_cfg/defaults/defaults_lbonly_c03_bay0.yml
        pysmurf_config: /data/pysmurf_cfg/experiment_ucsd_k2so_cc02-06_lbOnlyBay0.cfg
        device_config: $OCS_CONFIG_DIR/device_configs/dev_cfg_s2.yaml
```

The epics-server and some other parameters will be set to reasonable defaults like `smurf_server_s2` unless otherwise specified in command line args.

Sorry Matthew, metadata stuff is coming soon I swear! This has just been bothering me for a while.