### PR TITLE
Metadata variable groups

### DIFF
--- a/scripts/stream.py
+++ b/scripts/stream.py
@@ -74,8 +74,9 @@ def main():
         'txDevice': stream_root
     }
 
-    meta_file = cfg.get('meta_register_file')
+    meta_file = os.path.expandvars(cfg.get('meta_register_file'))
     if meta_file is not None:
+        print(f"Loading metadata registers from {meta_file}...")
         vgs = sosmurf.util.VariableGroups.from_file(meta_file)
         root_kwargs['VariableGroups'] = vgs.data
 

--- a/scripts/stream.py
+++ b/scripts/stream.py
@@ -61,8 +61,6 @@ def main():
         raise ValueError(
             f"comm_type is {comm_type}. Must be either 'eth'' or 'pcie'.")
 
-    vgs = sosmurf.util.get_metadata_groups(None)
-
     pcie_kwargs = {
         'lane': args.pcie_rssi_lane, 'ip_addr': args.ip_addr,
         'dev_rssi': args.pcie_dev_rssi, 'dev_data': args.pcie_dev_data,
@@ -73,8 +71,14 @@ def main():
         'epics_prefix': args.epics_prefix, 'polling_en': args.polling_en,
         'pv_dump_file': args.pv_dump_file, 'disable_bay0': args.disable_bay0,
         'disable_bay1': args.disable_bay1, 'configure': args.configure,
-        'txDevice': stream_root, 'VariableGroups': vgs,
+        'txDevice': stream_root
     }
+
+    meta_file = cfg.get('meta_register_file')
+    if meta_file is not None:
+        vgs = sosmurf.util.VariableGroups.from_file(meta_file)
+        root_kwargs['VariableGroups'] = vgs.data
+
     if comm_type == 'pcie':
         root_kwargs.update({
             'pcie_rssi_lane': args.pcie_rssi_lane,


### PR DESCRIPTION
This PR adds support for a meta_registers input file that determines how registers are streamed or published as metadata. The `meta_registers.yaml` file should contain a dictionary where the keys are the rogue registers. The values should be either ints, or a list [int, float]. The int determines the metatdata groups the variable should belong to, and right now should be either 1, 2, or 3, with 
1 being stream (send in the metadata stream), 2 being publish (through the pysmurf publisher) and 3 being stream and publish. The float if present determines the polling interval.

Since we need to set registers for groups of bands or channels, the yaml keys support a bit of templating so we can easily set the variable groups for collections of registers. For instance, the following yaml::
```
root.FpgaTopLevel.AppTop.AppCore:
    enableStreaming: [3, 1]
    SysgenCryo.Base[{{range(8)}}]:
        CryoChannels.CryoChannel[{{range(512)}}]:
            centerFrequencyMHz: 1
```
will cause the `enableStreaming` variable to be both streamed and published every second, and the center frequency of every channel on every band will be streamed.

I've tested the variable group system at UCSD and it works well. I had a bit of trouble finding the correct variables to use, since the conversion between the `centerFrequencyArray` that I thought we wanted to actual frequency isn't obvious. The centerFrequencyMHz value seems promising but I haven't actually tested to make sure that it is returning the correct channel frequency values.