### PR TITLE
Exposes dropped framecount vars in transmitter

### DIFF
--- a/meta_registers.yaml
+++ b/meta_registers.yaml
@@ -55,4 +55,4 @@ root.SmurfProcessor:
         Period: 1
     SOStream:
         dataDropCnt: 3
-        metaDrop Cnt: 3
+        metaDropCnt: 3

--- a/meta_registers.yaml
+++ b/meta_registers.yaml
@@ -4,8 +4,8 @@
 # iteration.
 #
 # Register values should be the bitwise | of their variable groups, with:
-#   stream (Sent in metadata stream):  1
-#   publish (Sent to pysmurf publisher): 2
+#     stream (Sent in metadata stream):  1
+#     publish (Sent to pysmurf publisher): 2
 #
 # If you want to set a polling interval, the value should be a list
 # [groups, poll_interval]
@@ -31,6 +31,9 @@ root.FpgaTopLevel:
     AmcCarrierCore.AxiVersion:
         Temperature: 1
 root.SmurfProcessor:
+    FrameRxStats:
+        FrameLossCnt: 3
+        FrameOutOrderCnt: 3
     ChannelMapper:
         NumChannels: 1
         PayloadSize: 1
@@ -50,3 +53,6 @@ root.SmurfProcessor:
         Amplitude: 1
         Offset: 1
         Period: 1
+    SOStream:
+        dataDropCnt: 3
+        metaDrop Cnt: 3

--- a/python/sosmurf/SmurfTransmitter/_SmurfTransmitter.py
+++ b/python/sosmurf/SmurfTransmitter/_SmurfTransmitter.py
@@ -33,6 +33,39 @@ class SmurfTransmitter(pyrogue.Device):
             localSet=lambda value: self._transmitter.setDebugMeta(value),
             localGet=self._transmitter.getDebugMeta))
 
+        # Add "Disable" variable
+        self.add(pyrogue.LocalVariable(
+            name='Disable',
+            description='Disable the processing block. Data will just pass thorough to the next slave.',
+            mode='RW',
+            value=False,
+            localSet=lambda value: self._transmitter.setDisable(value),
+            localGet=self._transmitter.getDisable))
+
+        # Add the data dropped counter variable
+        self.add(pyrogue.LocalVariable(
+            name='dataDropCnt',
+            description='Number of data frame dropped',
+            mode='RO',
+            value=0,
+            pollInterval=1,
+            localGet=self._transmitter.getDataDropCnt))
+
+        # Add the metaData dropped counter variable
+        self.add(pyrogue.LocalVariable(
+            name='metaDropCnt',
+            description='Number of metadata frame dropped',
+            mode='RO',
+            value=0,
+            pollInterval=1,
+            localGet=self._transmitter.getMetaDropCnt))
+
+        # Command to clear all the counters
+        self.add(pyrogue.LocalCommand(
+            name='clearCnt',
+            description='Clear all counters',
+            function=self._transmitter.clearCnt))
+
     def getDataChannel(self):
         return self._transmitter.getDataChannel()
 

--- a/python/sosmurf/StreamBase/_StreamBase.py
+++ b/python/sosmurf/StreamBase/_StreamBase.py
@@ -50,6 +50,39 @@ class StreamBase(pyrogue.Device):
             localSet=lambda value: self.builder.SetAggDuration(value),
             localGet=self.builder.GetAggDuration))
 
+        # Add "Disable" variable
+        self.add(pyrogue.LocalVariable(
+            name='Disable',
+            description='Disable the processing block. Data will just pass thorough to the next slave.',
+            mode='RW',
+            value=False,
+            localSet=lambda value: self._transmitter.setDisable(value),
+            localGet=self._transmitter.getDisable))
+
+        # Add the data dropped counter variable
+        self.add(pyrogue.LocalVariable(
+            name='dataDropCnt',
+            description='Number of data frame dropped',
+            mode='RO',
+            value=0,
+            pollInterval=1,
+            localGet=self._transmitter.getDataDropCnt))
+
+        # Add the metaData dropped counter variable
+        self.add(pyrogue.LocalVariable(
+            name='metaDropCnt',
+            description='Number of metadata frame dropped',
+            mode='RO',
+            value=0,
+            pollInterval=1,
+            localGet=self._transmitter.getMetaDropCnt))
+
+        # Command to clear all the counters
+        self.add(pyrogue.LocalCommand(
+            name='clearCnt',
+            description='Clear all counters',
+            function=self._transmitter.clearCnt))
+
 
     def getDataChannel(self):
         return self._transmitter.getDataChannel()

--- a/python/sosmurf/StreamBase/_StreamBase.py
+++ b/python/sosmurf/StreamBase/_StreamBase.py
@@ -53,7 +53,8 @@ class StreamBase(pyrogue.Device):
         # Add "Disable" variable
         self.add(pyrogue.LocalVariable(
             name='Disable',
-            description='Disable the processing block. Data will just pass thorough to the next slave.',
+            description="Disables the SmurfTransmitter, stopping the "
+                        "SmurfStreamer from receiving data from upstream",
             mode='RW',
             value=False,
             localSet=lambda value: self._transmitter.setDisable(value),
@@ -62,7 +63,8 @@ class StreamBase(pyrogue.Device):
         # Add the data dropped counter variable
         self.add(pyrogue.LocalVariable(
             name='dataDropCnt',
-            description='Number of data frame dropped',
+            description="Number of data frames dropped by the "
+                        "SmurfTransmitter's data buffer",
             mode='RO',
             value=0,
             pollInterval=1,
@@ -71,7 +73,8 @@ class StreamBase(pyrogue.Device):
         # Add the metaData dropped counter variable
         self.add(pyrogue.LocalVariable(
             name='metaDropCnt',
-            description='Number of metadata frame dropped',
+            description="Number of metadata frames dropped by the "
+                        "SmurfTransmitter's metadata buffer",
             mode='RO',
             value=0,
             pollInterval=1,
@@ -80,7 +83,7 @@ class StreamBase(pyrogue.Device):
         # Command to clear all the counters
         self.add(pyrogue.LocalCommand(
             name='clearCnt',
-            description='Clear all counters',
+            description='Clears dataDrop and metaDrop counters',
             function=self._transmitter.clearCnt))
 
 


### PR DESCRIPTION
This PR exposes the following Rogue variables from pysmurf's BaseTransmitter so that we are able to monitor them through OCS and put them in the G3 stream:

- `dataDropCnt`: Number of frames dropped by the Transmitter's data buffer
- `metaDropCnt`: Number of metadata frames dropped by the metadata buffer
- `Disable`: Settable variable which will stop the transmitter from receiving data from upstream.

I also add the drop-counts to the local meta-registers file, which will soon be used as the default if None is specified in the site-config.