### PR TITLE
Local G3 streaming

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,8 @@ WORKDIR /usr/local/src/smurf-streamer/build
 RUN cmake ..
 RUN make
 
+RUN pip3 install dumb-init
+
 ENV PYTHONPATH /usr/local/src/smurf-streamer/lib:${PYTHONPATH}
 ENV PYTHONPATH /usr/local/src/smurf-streamer/python:${PYTHONPATH}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,3 +13,4 @@ ENV PYTHONPATH /usr/local/src/smurf-streamer/lib:${PYTHONPATH}
 ENV PYTHONPATH /usr/local/src/smurf-streamer/python:${PYTHONPATH}
 
 WORKDIR /usr/local/src/smurf-streamer
+ENTRYPOINT /bin/bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,11 @@
 version: '3.7'
 
 services:
-    spt3g-pysmurf-server-base:
+    spt3g-smurf-base:
         image: spt3g-pysmurf-server-base
         build: ./docker/spt3g-pysmurf-server-base/
 
     smurf-streamer:
         image: smurf-streamer
         build: .
-        depends_on: [spt3g-pysmurf-server-base]
+        depends_on: [spt3g-smurf-base]

--- a/docker/spt3g-pysmurf-server-base/Dockerfile
+++ b/docker/spt3g-pysmurf-server-base/Dockerfile
@@ -1,5 +1,4 @@
-# FROM tidair/pysmurf-server:v4.0.0
-FROM tidair/pysmurf-server:v5.0.0-21-ge7326421
+FROM tidair/pysmurf-server:v5.0.2
 
 # Installs spt3g to /usr/local/src/
 WORKDIR /usr/local/src

--- a/docker/spt3g-pysmurf-server-base/Dockerfile
+++ b/docker/spt3g-pysmurf-server-base/Dockerfile
@@ -1,11 +1,11 @@
-FROM tidair/pysmurf-server:v4.0.0
+# FROM tidair/pysmurf-server:v4.0.0
+FROM tidair/pysmurf-server:v5.0.0-21-ge7326421
 
 # Installs spt3g to /usr/local/src/
-WORKDIR /usr/local/src/
-ENV TZ=America/New_York
-
+WORKDIR /usr/local/src
+ENV TZ=Etc/UTC
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
-# RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 6B05F25D762E3157
+
 RUN apt-get update
 
 RUN apt-get install -y \
@@ -19,19 +19,13 @@ RUN apt-get install -y \
     rsync \
     && rm -rf /var/lib/apt/lists/*
 
-
 RUN git clone https://github.com/CMB-S4/spt3g_software.git
-
-#WORKDIR /usr/local/src/spt3g_software/build
-#COPY tarballs/spt3g.tgz .
-#RUN tar zvxf spt3g.tgz
 
 RUN cd spt3g_software \
       && mkdir -p build \
       && cd build \
       && cmake .. -DPYTHON_EXECUTABLE=`which python3` \
       && make core version
-
 
 ENV SPT3G_SOFTWARE_PATH /usr/local/src/spt3g_software
 ENV SPT3G_SOFTWARE_BUILD_PATH /usr/local/src/spt3g_software/build

--- a/include/SmurfSample.h
+++ b/include/SmurfSample.h
@@ -12,6 +12,9 @@
 
 #define N_TES_BIAS 16
 
+using SmurfPacketRO = SmurfPacketManagerRO<ZeroCopyCreator>;
+using SmurfPacketROPtr = SmurfPacketManagerROPtr<ZeroCopyCreator>;
+
 class StatusSample : public G3FrameObject{
 public:
     StatusSample(): G3FrameObject(), time_(0) {}

--- a/include/SmurfTransmitter.h
+++ b/include/SmurfTransmitter.h
@@ -17,6 +17,9 @@
 namespace bp = boost::python;
 namespace sct = smurf::core::transmitters;
 
+using SmurfPacketRO = SmurfPacketManagerRO<ZeroCopyCreator>;
+using SmurfPacketROPtr = SmurfPacketManagerROPtr<ZeroCopyCreator>;
+
 /*
  *  Sample object passed to SmurfBuilder object
  */

--- a/python/sosmurf/SOFileWriter/_SOFileWriter.py
+++ b/python/sosmurf/SOFileWriter/_SOFileWriter.py
@@ -36,6 +36,12 @@ class G3Rotator:
     def set_debug(self, debug):
         self.debug = debug
 
+    def get_disable(self):
+        return self.disable
+
+    def set_disable(self, value):
+        self.disable = value
+
     def close_writer(self):
         if self._writer is not None:
             self.cur_path = ''
@@ -94,6 +100,8 @@ class G3Rotator:
 
     def __call__(self, frame):
         if self.disable:
+            if self.debug:
+                print(frame)
             return [frame]
 
         writer = self.get_writer(frame)
@@ -117,8 +125,8 @@ class SOFileWriter(pyrogue.Device):
             description="Disables G3Writer and passes frame to next module",
             mode='RW',
             value=False,
-            localGet=lambda: self.rotator.disable,
-            localSet=(lambda value: self.rotator.disable = value),
+            localGet=self.rotator.get_disable,
+            localSet=(lambda value: self.rotator.set_disable(value)),
         ))
 
         self.add(pyrogue.LocalVariable(

--- a/python/sosmurf/SOFileWriter/_SOFileWriter.py
+++ b/python/sosmurf/SOFileWriter/_SOFileWriter.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+
+import pyrogue
+from spt3g import core
+import os
+import time
+from sosmurf.SessionManager import FlowControl
+
+class G3Rotator:
+    def __init__(self, data_path, file_dur):
+        self.data_path = data_path
+        self._writer = None
+        self.seq = 0
+        self.cur_session_id = 0
+        self.file_start_time = 0
+        self.file_dur = file_dur
+        self.cur_path = ''
+
+    def get_cur_path(self):
+        return self.cur_path
+
+    def get_session_id(self):
+        return self.cur_session_id
+
+    def close_writer(self):
+        if self._writer is not None:
+            self.cur_path = ''
+            self.file_start_time = 0
+            self.cur_session_id = 0
+            self._writer(core.G3Frame(core.G3FrameType.EndProcessing))
+        self._writer = None
+
+    def new_writer(self, frame, seq):
+        session_id = frame['session_id']
+        stream_id = frame['sostream_id']
+        subdir = os.path.join(self.data_path, stream_id, str(session_id)[:5])
+        fname = f"{session_id}_{seq:03}.g3"
+        fpath = os.path.join(subdir, fname)
+
+        if not os.path.exists(subdir):
+            os.makedirs(subdir)
+
+        self._writer = core.G3Writer(fpath)
+        self.cur_path = fpath
+        self.file_start_time = time.time()
+        self.cur_session_id = session_id
+
+        return self._writer
+
+    def new_file_condition(self, frame):
+        return time.time() > self.file_start_time + self.file_dur
+
+    def get_writer(self, frame):
+        """
+        Gets appropriate G3 writer for a given frame based on the following
+        rules. Will automatically rotate files if `new_file_condition` has
+        been met, and will close out files if an FlowControl.End frame is
+        received.
+        """
+        if 'sostream_flowcontrol' in frame:
+            if frame['sostream_flowcontrol'] == FlowControl.END.value:
+                self.close_writer()
+            return None
+
+        if 'session_id' not in frame:
+            return None
+        sess_id = frame['session_id']
+
+        if self.cur_session_id != sess_id:
+            self.close_writer()
+            self.seq = 0
+            return self.new_writer(frame, self.seq)
+
+        elif self.new_file_condition(frame):
+            self.close_writer()
+            self.seq += 1
+            return self.new_writer(frame, self.seq)
+
+    def __call__(self, frame):
+        writer = self.get_writer(frame)
+        if writer is not None:
+            writer(frame)
+        return [frame]
+
+class SOFileWriter(pyrogue.Device):
+    def __init__(self, name, data_path, file_dur=30*60):
+        pyrogue.Device.__init__(self, name=name, description="G3 File Rotator")
+        self.rotator = G3Rotator(data_path, file_dur)
+        self.add(pyrogue.LocalVariable(
+            name="filepath",
+            description="Path to the current G3 file",
+            mode='RO',
+            value='',
+            localGet=self.rotator.get_cur_path
+        ))
+
+        self.add(pyrogue.LocalVariable(
+            name="session_id",
+            description="Current stream session-id",
+            mode='RO',
+            value=0,
+            localGet=self.rotator.get_session_id
+        ))

--- a/python/sosmurf/SOFileWriter/__init__.py
+++ b/python/sosmurf/SOFileWriter/__init__.py
@@ -1,0 +1,1 @@
+from sosmurf.SOFileWriter._SOFileWriter import SOFileWriter

--- a/python/sosmurf/SessionManager.py
+++ b/python/sosmurf/SessionManager.py
@@ -31,7 +31,7 @@ class SessionManager:
         Creates flow control frame.
 
         Args:
-            fc (int): 
+            fc (int):
                 flow control type
         """
         frame = core.G3Frame(core.G3FrameType.none)

--- a/python/sosmurf/SessionManager.py
+++ b/python/sosmurf/SessionManager.py
@@ -90,7 +90,7 @@ class SessionManager:
                 self.session_id = None
                 self.end_session_flag = False
                 self.frame_num = 0
-
+                return out
 
         #######################################
         # On Scan frames

--- a/python/sosmurf/StreamBase/_StreamBase.py
+++ b/python/sosmurf/StreamBase/_StreamBase.py
@@ -86,6 +86,27 @@ class StreamBase(pyrogue.Device):
             description='Clears dataDrop and metaDrop counters',
             function=self._transmitter.clearCnt))
 
+        self.add(pyrogue.LocalVariable(
+            name="pysmurf_action",
+            description="Current pysmurf action",
+            mode='RW',
+            value='',
+        ))
+
+        self.add(pyrogue.LocalVariable(
+            name="pysmurf_action_timestamp",
+            description="Current pysmurf action timestamp",
+            mode='RW',
+            value=0,
+        ))
+
+        self.add(pyrogue.LocalVariable(
+            name="stream_tag",
+            description="Tag associated with data stream",
+            mode='RW',
+            value='',
+        ))
+
 
     def getDataChannel(self):
         return self._transmitter.getDataChannel()

--- a/python/sosmurf/__init__.py
+++ b/python/sosmurf/__init__.py
@@ -3,3 +3,4 @@ import sosmurf.SessionManager
 
 from sosmurf.SmurfTransmitter import SmurfTransmitter
 from sosmurf.StreamBase import StreamBase
+from sosmurf.SOFileWriter import SOFileWriter

--- a/python/sosmurf/util.py
+++ b/python/sosmurf/util.py
@@ -38,7 +38,12 @@ def setup_server(cfg, slot):
     pre_parser.add_argument('--shelfmanager', '-S')
     pre_parser.add_argument('--addr', '-a')
     pre_parser.add_argument('--comm-type', '-c')
+    pre_parser.add_argument('--emulate', action='store_true')
     args, _ = pre_parser.parse_known_args()
+
+    if args.emulate:
+        return ' '.join(sys.argv[1:])
+
     setup_args = sys.argv[1:]
 
     if args.shelfmanager is None:

--- a/scripts/stream.py
+++ b/scripts/stream.py
@@ -68,8 +68,8 @@ def main():
     pipe.Add(stream_root.builder)
     pipe.Add(sosmurf.SessionManager.SessionManager, stream_id=args.stream_id)
     # pipe.Add(sosmurf.util.stream_dumper)
-    # pipe.Add(core.G3NetworkSender, hostname='*',
-    #         port=args.stream_port, max_queue_size=1000)
+    pipe.Add(core.G3NetworkSender, hostname='*',
+             port=args.stream_port, max_queue_size=1000)
     pipe.Add(file_writer.rotator)
 
     meta_file = os.path.expandvars(cfg.get('meta_register_file'))

--- a/scripts/stream.py
+++ b/scripts/stream.py
@@ -46,6 +46,7 @@ def main():
     if not args.epics_prefix:
         if args.emulate:
             args.epics_prefix = f"smurf_emulator_s{slot}"
+            args.server_port = 9000 + 2*slot
         else:
             args.epics_prefix = f"smurf_server_s{slot}"
         print(f"Using epics root {args.epics_prefix}")

--- a/scripts/stream.py
+++ b/scripts/stream.py
@@ -59,7 +59,7 @@ def main():
         print(f"Using pcie lane {args.pcie_rssi_lane}")
 
     stream_root = sosmurf.StreamBase("SOStream", debug_meta=False,
-                                     debug_data=False, agg_time=1.0)
+                                     debug_data=False, agg_time=5.0)
     file_writer = sosmurf.SOFileWriter("SOFileWriter", g3_dir, file_dur=30)
     stream_root.add(file_writer)
 

--- a/scripts/stream.py
+++ b/scripts/stream.py
@@ -61,7 +61,7 @@ def main():
 
     stream_root = sosmurf.StreamBase("SOStream", debug_meta=False,
                                      debug_data=False, agg_time=5.0)
-    file_writer = sosmurf.SOFileWriter("SOFileWriter", g3_dir, file_dur=30)
+    file_writer = sosmurf.SOFileWriter("SOFileWriter", g3_dir, file_dur=10*60)
     stream_root.add(file_writer)
 
     pipe = core.G3Pipeline()

--- a/src/python.cpp
+++ b/src/python.cpp
@@ -3,6 +3,9 @@
 
 namespace bp = boost::python;
 
+using SmurfPacketRO = SmurfPacketManagerRO<ZeroCopyCreator>;
+using SmurfPacketROPtr = SmurfPacketManagerROPtr<ZeroCopyCreator>;
+
 BOOST_PYTHON_MODULE(sosmurfcore){
     bp::import("rogue");
     bp::import("spt3g.core");

--- a/src/python.cpp
+++ b/src/python.cpp
@@ -3,9 +3,6 @@
 
 namespace bp = boost::python;
 
-using SmurfPacketRO = SmurfPacketManagerRO<ZeroCopyCreator>;
-using SmurfPacketROPtr = SmurfPacketManagerROPtr<ZeroCopyCreator>;
-
 BOOST_PYTHON_MODULE(sosmurfcore){
     bp::import("rogue");
     bp::import("spt3g.core");


### PR DESCRIPTION
This branch adds the ability to stream directly to g3-files written on the smurf-server. This involved a bunch of changes and updates, including:
- Switch base pysmurf version to `tidair/pysmurf-server:v5.0.0-21-ge7326421`, which includes the FrameDrop fix
- Adds the SOFileWriter Rogue Device, which contains a FileRotator that writes g3 frames to disk, rotating the file after a specified amount of time has passed (defaults to 10 min per file)
  - Adds a bunch of rogue vars so you can monitor the session-id / filename from pysmurf, and can disable / update the file-duration without hammering.
- Fixes a few bugs in the SessionManager
- Combines the emulate/streaming script so you can enable emulation mode with just a keyword argument. This is to make sure we're using the same G3Pipeline/metadata setup for each

I've tested in both emulator mode and with direct access to a smurf-server (but no resonators).