### PR TITLE
Change stream trigger to FileWriter:IsOpen

### DIFF
--- a/python/sosmurf/SessionManager.py
+++ b/python/sosmurf/SessionManager.py
@@ -16,8 +16,7 @@ class FlowControl(Enum):
 
 
 class SessionManager:
-    #enable_streams = "AMCc.FpgaTopLevel.AppTop.AppCore.StreamControl.EnableStreams"
-    enable_streams = "AMCc.FpgaTopLevel.AppTop.AppCore.enableStreaming"
+    enable_streams = "AMCc.SmurfProcessor.FileWriter.IsOpen"
 
     def __init__(self, stream_id=''):
         self.stream_id = stream_id
@@ -98,15 +97,7 @@ class SessionManager:
         elif frame.type == core.G3FrameType.Scan:
 
             if self.session_id is None:
-                # Returns [start, session, data]
-                session_frame = self.start_session()
-                status_frame = self.status_frame()
-                out = [
-                    self.flowcontrol_frame(FlowControl.START),
-                    session_frame,
-                    status_frame,
-                    frame
-                ]
+                return []
 
             self.tag_frame(frame)
             return out


### PR DESCRIPTION
When testing on k2so, I realized that there were a number of bugs coming from the fact that pysmurf only records data when FileWriter:IsOpen is set to True. We were recording all data being streamed (with `S.set_stream_enable(1)`), was causing a few issues:
- data was being streamed before the data-mask was set, causing the number of channels to change after the G3 file has been started (https://github.com/slaclab/pysmurf/issues/653)
- We were recording data being streamed during setup (https://github.com/slaclab/pysmurf/issues/652)
- We were recording data before the SmurfProcessor filter was settled.

This PR changes the stream-trigger to the FileWriter:IsOpen variable instead of the `enableStreaming`, and doesn't allow data to be written to disk before this is set, which should prevent these cases from happening. 

The FileWriter variables must be added to the metadata file in order for these to be processed by the session manager. See here: https://github.com/simonsobs/ocs-site-configs/blob/master/ucsd/k2so/smurf-srv14/meta_registers.yaml
Setting a regular polling interval here will make it so that we don't miss too much data even in the unlikely event where the FileWriter status update is dropped.