### PR TITLE
V0.3.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,20 +14,30 @@
 # ----------------------------------------------------------------------------
 
 # Check cmake version
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required (VERSION 3.1)
 include(InstallRequiredSystemLibraries)
+
+# cmake policies -- best to keep these in sync with spt3g!
+if(POLICY CMP0060) # Suppress cmake stripping full paths from libraries in some cases
+  cmake_policy(SET CMP0060 NEW)
+endif()
+cmake_policy(SET CMP0012 NEW) # Allow use of true in boolean expressions
+if(POLICY CMP0042) # Enable RPATH on OSX
+   cmake_policy(SET CMP0042 NEW)
+endif()
 
 # Project name
 project (SmurfStreamer)
 
 # C/C++
 enable_language(CXX)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x -Wno-deprecated")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x -Wno-deprecated -O3")
 
 #####################################
 # Link SPT3g Libraries
 #####################################
 set(SPT3G_DIR $ENV{SPT3G_SOFTWARE_PATH})
+set(SO3G_DIR $ENV{SO3G_DIR})
 link_directories(${SPT3G_DIR}/build/spt3g)
 
 #####################################
@@ -73,6 +83,8 @@ include_directories(${SMURF_INCLUDE_DIRS})
 include_directories(${SPT3G_DIR}/core/include/core)
 include_directories(${SPT3G_DIR}/core/include)
 include_directories(${SPT3G_DIR}/core/src)
+include_directories(${SO3G_DIR}/include)
+
 
 include_directories(/usr/local/include/)
 include_directories(${PROJECT_SOURCE_DIR}/include/)
@@ -88,4 +100,5 @@ set_target_properties(SmurfStreamer PROPERTIES OUTPUT_NAME "sosmurfcore")
 
 # Link to rogue core
 TARGET_LINK_LIBRARIES(SmurfStreamer LINK_PUBLIC ${ROGUE_LIBRARIES} ${SMURF_LIBRARIES})
-TARGET_LINK_LIBRARIES(SmurfStreamer LINK_PUBLIC ${SPT3G_DIR}/build/spt3g/core.so)
+TARGET_LINK_LIBRARIES(SmurfStreamer LINK_PUBLIC ${SPT3G_DIR}/build/spt3g/libspt3g-core.so)
+TARGET_LINK_LIBRARIES(SmurfStreamer LINK_PUBLIC ${SO3G_DIR}/build/so3g/libso3g.so)

--- a/docker/spt3g-pysmurf-server-base/Dockerfile
+++ b/docker/spt3g-pysmurf-server-base/Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get update --fix-missing \
         build-essential \
         automake \
         gfortran \
+        libbz2-dev \
     && rm -rf /var/lib/apt/lists/*
 
 RUN git clone https://github.com/CMB-S4/spt3g_software.git
@@ -35,7 +36,7 @@ ENV PYTHONPATH /usr/local/src/spt3g_software/build:${PYTHONPATH}
 
 # SO3G install
 WORKDIR /usr/local/src
-RUN git clone https://github.com/simonsobs/so3g.git -b super-timestream
+RUN git clone https://github.com/simonsobs/so3g.git
 ENV LANG C.UTF-8
 WORKDIR /usr/local/src/so3g
 
@@ -47,3 +48,7 @@ RUN mkdir -p build \
     && make install
 
 env SO3G_DIR /usr/local/src/so3g
+
+# Install pysmurf-client requirements so we can use the client-version of the
+# pysmurf publisher
+RUN pip3 install -r /usr/local/src/pysmurf/requirements.txt

--- a/docker/spt3g-pysmurf-server-base/Dockerfile
+++ b/docker/spt3g-pysmurf-server-base/Dockerfile
@@ -5,18 +5,20 @@ WORKDIR /usr/local/src
 ENV TZ=Etc/UTC
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
-RUN apt-get update --fix-missing
-
-RUN apt-get install -y \
-    libflac-dev \
-    libnetcdf-dev \
-    libfftw3-dev \
-    libgsl0-dev \
-    tcl \
-    environment-modules \
-    gdb \
-    rsync \
-    libopenblas-dev \
+RUN apt-get update --fix-missing \
+    && apt-get install -y \
+        libflac-dev \
+        libnetcdf-dev \
+        libfftw3-dev \
+        libgsl0-dev \
+        tcl \
+        environment-modules \
+        gdb \
+        rsync \
+        libopenblas-dev \
+        build-essential \
+        automake \
+        gfortran \
     && rm -rf /var/lib/apt/lists/*
 
 RUN git clone https://github.com/CMB-S4/spt3g_software.git
@@ -36,12 +38,6 @@ WORKDIR /usr/local/src
 RUN git clone https://github.com/simonsobs/so3g.git -b super-timestream
 ENV LANG C.UTF-8
 WORKDIR /usr/local/src/so3g
-
-RUN apt update && apt install -y \
-    build-essential \
-    automake \
-    gfortran 
-
 
 RUN pip3 install -r requirements.txt
 RUN mkdir -p build \

--- a/docker/spt3g-pysmurf-server-base/Dockerfile
+++ b/docker/spt3g-pysmurf-server-base/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /usr/local/src
 ENV TZ=Etc/UTC
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
-RUN apt-get update
+RUN apt-get update --fix-missing
 
 RUN apt-get install -y \
     libflac-dev \
@@ -16,6 +16,7 @@ RUN apt-get install -y \
     environment-modules \
     gdb \
     rsync \
+    libopenblas-dev \
     && rm -rf /var/lib/apt/lists/*
 
 RUN git clone https://github.com/CMB-S4/spt3g_software.git
@@ -29,3 +30,24 @@ RUN cd spt3g_software \
 ENV SPT3G_SOFTWARE_PATH /usr/local/src/spt3g_software
 ENV SPT3G_SOFTWARE_BUILD_PATH /usr/local/src/spt3g_software/build
 ENV PYTHONPATH /usr/local/src/spt3g_software/build:${PYTHONPATH}
+
+# SO3G install
+WORKDIR /usr/local/src
+RUN git clone https://github.com/simonsobs/so3g.git -b super-timestream
+ENV LANG C.UTF-8
+WORKDIR /usr/local/src/so3g
+
+RUN apt update && apt install -y \
+    build-essential \
+    automake \
+    gfortran 
+
+
+RUN pip3 install -r requirements.txt
+RUN mkdir -p build \
+    && cd build \
+    && cmake .. -DCMAKE_PREFIX_PATH=$SPT3G_SOFTWARE_BUILD_PATH \
+    && make -j 16 \
+    && make install
+
+env SO3G_DIR /usr/local/src/so3g

--- a/include/SmurfBuilder.h
+++ b/include/SmurfBuilder.h
@@ -39,16 +39,16 @@ public:
     const bool getEncode() {return encode_timestreams_;};
 
     void setDataEncodeAlgo(int algo);
-    const int getDataEncodeAlgo();
+    int getDataEncodeAlgo() const;
 
     void setPrimaryEncodeAlgo(int algo);
-    const int getPrimaryEncodeAlgo();
+    int getPrimaryEncodeAlgo() const;
 
     void setTesBiasEncodeAlgo(int algo);
-    const int getTesBiasEncodeAlgo();
+    int getTesBiasEncodeAlgo() const;
 
     void setTimeEncodeAlgo(int algo);
-    const int getTimeEncodeAlgo();
+    int getTimeEncodeAlgo() const;
 
 protected:
     void ProcessNewData();

--- a/include/SmurfBuilder.h
+++ b/include/SmurfBuilder.h
@@ -50,6 +50,15 @@ public:
     void setTimeEncodeAlgo(int algo);
     int getTimeEncodeAlgo() const;
 
+    void setEnableCompression(int enable);
+    int getEnableCompression() const;
+
+    void setBz2WorkFactor(int bz2_workfactor);
+    int getBz2WorkFactor() const;
+
+    void setFlacLevel(int flac_level);
+    int getFlacLevel() const;
+
 protected:
     void ProcessNewData();
 
@@ -79,6 +88,9 @@ private:
     int primary_encode_algo_;
     int tes_bias_encode_algo_;
     int time_encode_algo_;
+    int enable_compression_;
+    int bz2_work_factor_;
+    int flac_level_;
 
     bool running_;
     bool debug_;

--- a/include/SmurfBuilder.h
+++ b/include/SmurfBuilder.h
@@ -24,6 +24,10 @@ public:
 
     static void setup_python();
 
+    G3FramePtr FrameFromSamples(
+            std::deque<SmurfSampleConstPtr>::iterator start,
+            std::deque<SmurfSampleConstPtr>::iterator stop);
+
     float agg_duration_; // Aggregation duration in seconds
     void SetAggDuration(float dur){ agg_duration_ = dur;};
     const float GetAggDuration(){ return agg_duration_; };

--- a/include/SmurfBuilder.h
+++ b/include/SmurfBuilder.h
@@ -34,7 +34,21 @@ public:
 
     void       setDebug(bool d) { debug_ = d;    };
     const bool getDebug()       { return debug_; };
-    void test(int a, int b, int c);
+
+    void setEncode(bool b) { encode_timestreams_ = b; };
+    const bool getEncode() {return encode_timestreams_;};
+
+    void setDataEncodeAlgo(int algo);
+    const int getDataEncodeAlgo();
+
+    void setPrimaryEncodeAlgo(int algo);
+    const int getPrimaryEncodeAlgo();
+
+    void setTesBiasEncodeAlgo(int algo);
+    const int getTesBiasEncodeAlgo();
+
+    void setTimeEncodeAlgo(int algo);
+    const int getTimeEncodeAlgo();
 
 protected:
     void ProcessNewData();
@@ -55,8 +69,20 @@ private:
     // Calls FlushStash every agg_duration_ seconds
     static void ProcessStashThread(SmurfBuilder *);
 
+    // Sets SuperTimestream encoding algorithms:
+    //   - 0: No compression
+    //   - 1: FLAC only
+    //   - 2: bzip only
+    //   - 3: FLAC + bzip
+    // See So3G docs for more info.
+    int data_encode_algo_;
+    int primary_encode_algo_;
+    int tes_bias_encode_algo_;
+    int time_encode_algo_;
+
     bool running_;
     bool debug_;
+    bool encode_timestreams_;
 
     std::thread process_stash_thread_;
 

--- a/include/SmurfBuilder.h
+++ b/include/SmurfBuilder.h
@@ -34,6 +34,7 @@ public:
 
     void       setDebug(bool d) { debug_ = d;    };
     const bool getDebug()       { return debug_; };
+    void test(int a, int b, int c);
 
 protected:
     void ProcessNewData();

--- a/include/smurf_streamer_numpy_init.h
+++ b/include/smurf_streamer_numpy_init.h
@@ -1,0 +1,2 @@
+#define PY_ARRAY_UNIQUE_SYMBOL smurf_streamer_ARRAY_API
+#include "numpy/arrayobject.h"

--- a/meta_registers.yaml
+++ b/meta_registers.yaml
@@ -4,41 +4,43 @@
 # iteration.
 #
 # Register values should be the bitwise | of their variable groups, with:
-#     stream (Sent in metadata stream):  1
-#     publish (Sent to pysmurf publisher): 2
+#   stream (Sent in metadata stream):  1
+#   publish (Sent to pysmurf publisher): 2
 #
 # If you want to set a polling interval, the value should be a list
 # [groups, poll_interval]
 ################################################################################
 root.RogueVersion: 3
 root.RogueDirectory: 3
-root.SmurfApplication: 3
-root.FpgaTopLevel:
-    AppTop.AppCore:
-        enableStreaming: 3
-        SysgenCryo.Base[{{range(8)}}]:
-            band: 1
-            bandCenterMHz: 1
-            toneFrequencyOffsetMHz: 1
-            CryoChannels:
-                centerFrequencyArray: 1
-                amplitudeScaleArray: 1
-                etaMagArray: 1
-                etaPhaseArray: 1
-        RtmCryoDet:
-            RampMaxCnt: 1
-            EnableRampTrigger: 1
-    AmcCarrierCore.AxiVersion:
-        Temperature: 1
+root.FpgaTopLevel.AppTop.AppCore:
+    enableStreaming: 3
+    SysgenCryo:
+      tuneFilePath: 3
+      Base[{{range(8)}}]:
+        band: 1
+        ScratchPad: 3
+        bandCenterMHz: 1
+        toneFrequencyOffsetMHz: 1
+        CryoChannels:
+            centerFrequencyArray: 1
+            amplitudeScaleArray: 1
+            etaMagArray: 1
+            etaPhaseArray: 1
+    RtmCryoDet:
+        RampMaxCnt: 1
+        EnableRampTrigger: 1
+root.FpgaTopLevel.AmcCarrierCore.AxiSysMonUltraScale:
+    Temperature: [3, 1]
 root.SmurfProcessor:
-    FrameRxStats:
-        FrameLossCnt: 3
-        FrameOutOrderCnt: 3
     ChannelMapper:
         NumChannels: 1
         PayloadSize: 1
-        Mask: 1
-    Filter:
+        Mask: [1, 10]
+    FrameRxStats:
+        FrameLossCnt: 3
+        FrameOutOrderCnt: 3
+        BadFrameCnt: 3
+    Filter: 
         Disable: 1
         Order: 1
         Gain: 1
@@ -53,6 +55,16 @@ root.SmurfProcessor:
         Amplitude: 1
         Offset: 1
         Period: 1
+    FileWriter:
+        IsOpen: [3, 5]
+        DataFile: 3
+    BandPhaseFeedback[{{range(8)}}]:
+        Tau: 1
+        Theta: 1
     SOStream:
         dataDropCnt: 3
         metaDropCnt: 3
+        pysmurf_action: 3
+        pysmurf_action_timestamp: 3
+        stream_tag: 3
+        open_g3stream: 3

--- a/python/sosmurf/SessionManager.py
+++ b/python/sosmurf/SessionManager.py
@@ -7,6 +7,11 @@ from enum import Enum
 SOSTREAM_VERSION = 1
 
 
+class Registers:
+    datfile_open = 'AMCc.SmurfProcessor.FileWriter.IsOpen'
+    g3stream_open = 'AMCc.SmurfProcessor.SOStream.open_g3stream'
+
+
 class FlowControl(Enum):
     """Flow control enumeration."""
     ALIVE = 0
@@ -16,7 +21,6 @@ class FlowControl(Enum):
 
 
 class SessionManager:
-    enable_streams = "AMCc.SmurfProcessor.FileWriter.IsOpen"
 
     def __init__(self, stream_id=''):
         self.stream_id = stream_id
@@ -125,9 +129,11 @@ class SessionManager:
             del frame['status']
             frame['status'] = yaml.dump(diff)
 
-            enable = int(status_update.get(self.enable_streams, -1))
+            datfile_open = int(status_update.get(Registers.datfile_open, -1))
+            g3stream_open = int(status_update.get(Registers.g3stream_open, -1))
+
             if self.session_id is None:
-                if enable == 1:
+                if (datfile_open == 1) or (g3stream_open == 1):
                     # Returns [start, session, status]
                     session_frame = self.start_session()
                     out = [
@@ -142,7 +148,7 @@ class SessionManager:
                     return []
             else:
                 frame['dump'] = 0
-                if enable == 0:
+                if (datfile_open == 0) or (g3stream_open == 0):
                     self.end_session_flag = True
                 self.tag_frame(frame)
                 return out

--- a/python/sosmurf/SessionManager.py
+++ b/python/sosmurf/SessionManager.py
@@ -4,7 +4,7 @@ import time
 from enum import Enum
 
 
-SOSTREAM_VERSION = 1
+SOSTREAM_VERSION = 2
 
 
 class Registers:

--- a/python/sosmurf/StreamBase/_StreamBase.py
+++ b/python/sosmurf/StreamBase/_StreamBase.py
@@ -8,7 +8,10 @@ class StreamBase(pyrogue.Device):
     """
         Stream Base pyrogue object.
     """
-    def __init__(self, name, debug_data=False, debug_meta=False, debug_builder=False, agg_time=1.0, **kwargs):
+    def __init__(self, name, debug_data=False, debug_meta=False,
+                 debug_builder=False, agg_time=1.0, builder_encode=False,
+                 data_algo=0, tes_bias_algo=0, primary_algo=0, time_algo=0,
+                 **kwargs):
         pyrogue.Device.__init__(self, name=name, description='SMuRF Data CustomTransmitter', **kwargs)
 
         self.builder = sosmurfcore.SmurfBuilder()
@@ -40,6 +43,46 @@ class StreamBase(pyrogue.Device):
             value=debug_builder,
             localSet=lambda value: self.builder.setDebug(value),
             localGet=self.builder.getDebug))
+
+        self.add(pyrogue.LocalVariable(
+            name='BuilderEncode',
+            description='Set the debug mode for the Smurfbuilder',
+            mode='RW',
+            value=builder_encode,
+            localSet=lambda value: self.builder.setEncode(value),
+            localGet=self.builder.getEncode))
+
+        self.add(pyrogue.LocalVariable(
+            name='DataEncodeAlgo',
+            description='Sets the algorithm used to compress data timestreams',
+            mode='RW',
+            value=data_algo,
+            localSet=lambda value: self.builder.setDataEncodeAlgo(value),
+            localGet=self.builder.getDataEncodeAlgo))
+
+        self.add(pyrogue.LocalVariable(
+            name='PrimaryEncodeAlgo',
+            description='Sets the algorithm used to compress primary timestreams',
+            mode='RW',
+            value=primary_algo,
+            localSet=lambda value: self.builder.setPrimaryEncodeAlgo(value),
+            localGet=self.builder.getPrimaryEncodeAlgo))
+
+        self.add(pyrogue.LocalVariable(
+            name='TesBiasEncodeAlgo',
+            description='Sets the algorithm used to compress tes bias timestreams',
+            mode='RW',
+            value=tes_bias_algo,
+            localSet=lambda value: self.builder.setTesBiasEncodeAlgo(value),
+            localGet=self.builder.getTesBiasEncodeAlgo))
+
+        self.add(pyrogue.LocalVariable(
+            name='TimeEncodeAlgo',
+            description='Sets the algorithm used to compress the time fields of all timestreams',
+            mode='RW',
+            value=time_algo,
+            localSet=lambda value: self.builder.setTimeEncodeAlgo(value),
+            localGet=self.builder.getTimeEncodeAlgo))
 
         self.add(pyrogue.LocalVariable(
             name='AggTime',
@@ -113,7 +156,6 @@ class StreamBase(pyrogue.Device):
             mode='RW',
             value=0,
         ))
-
 
     def getDataChannel(self):
         return self._transmitter.getDataChannel()

--- a/python/sosmurf/StreamBase/_StreamBase.py
+++ b/python/sosmurf/StreamBase/_StreamBase.py
@@ -10,7 +10,7 @@ class StreamBase(pyrogue.Device):
     """
     def __init__(self, name, debug_data=False, debug_meta=False,
                  debug_builder=False, agg_time=1.0, builder_encode=False,
-                 data_algo=3, tes_bias_algo=3, primary_algo=3, time_algo=3,
+                 data_algo=3, tes_bias_algo=2, primary_algo=2, time_algo=2,
                  enable_compression=1, bz2_work_factor=1, flac_level=3,
                  **kwargs):
         pyrogue.Device.__init__(self, name=name, description='SMuRF Data CustomTransmitter', **kwargs)

--- a/python/sosmurf/StreamBase/_StreamBase.py
+++ b/python/sosmurf/StreamBase/_StreamBase.py
@@ -107,6 +107,13 @@ class StreamBase(pyrogue.Device):
             value='',
         ))
 
+        self.add(pyrogue.LocalVariable(
+            name="open_g3stream",
+            description="Opens the G3 data stream",
+            mode='RW',
+            value=0,
+        ))
+
 
     def getDataChannel(self):
         return self._transmitter.getDataChannel()

--- a/python/sosmurf/StreamBase/_StreamBase.py
+++ b/python/sosmurf/StreamBase/_StreamBase.py
@@ -10,14 +10,14 @@ class StreamBase(pyrogue.Device):
     """
     def __init__(self, name, debug_data=False, debug_meta=False,
                  debug_builder=False, agg_time=1.0, builder_encode=False,
-                 data_algo=0, tes_bias_algo=0, primary_algo=0, time_algo=0,
+                 data_algo=3, tes_bias_algo=3, primary_algo=3, time_algo=3,
+                 enable_compression=1, bz2_work_factor=1, flac_level=3,
                  **kwargs):
         pyrogue.Device.__init__(self, name=name, description='SMuRF Data CustomTransmitter', **kwargs)
 
         self.builder = sosmurfcore.SmurfBuilder()
         self._transmitter = sosmurfcore.SmurfTransmitter(self.builder, debug_data, debug_meta)
 
-        # Add pyrogue variables here!!
         self.add(pyrogue.LocalVariable(
             name='DebugData',
             description='Set the debug mode, for the data',
@@ -26,7 +26,6 @@ class StreamBase(pyrogue.Device):
             localSet=lambda value: self._transmitter.setDebugData(value),
             localGet=self._transmitter.getDebugData))
 
-        # Add a variable for the debugMeta flag
         self.add(pyrogue.LocalVariable(
             name='DebugMeta',
             description='Set the debug mode, for the metadata',
@@ -35,7 +34,6 @@ class StreamBase(pyrogue.Device):
             localSet=lambda value: self._transmitter.setDebugMeta(value),
             localGet=self._transmitter.getDebugMeta))
 
-        # Add a variable for the Builder flag
         self.add(pyrogue.LocalVariable(
             name='DebugBuilder',
             description='Set the debug mode for the Smurfbuilder',
@@ -51,6 +49,10 @@ class StreamBase(pyrogue.Device):
             value=builder_encode,
             localSet=lambda value: self.builder.setEncode(value),
             localGet=self.builder.getEncode))
+
+        ######################################################################
+        # Encoding options
+        ######################################################################
 
         self.add(pyrogue.LocalVariable(
             name='DataEncodeAlgo',
@@ -83,6 +85,30 @@ class StreamBase(pyrogue.Device):
             value=time_algo,
             localSet=lambda value: self.builder.setTimeEncodeAlgo(value),
             localGet=self.builder.getTimeEncodeAlgo))
+
+        self.add(pyrogue.LocalVariable(
+            name='EnableCompression',
+            description='If true, data will be compressed on serialization',
+            mode='RW',
+            value=enable_compression,
+            localSet=lambda value: self.builder.setEnableCompression(value),
+            localGet=self.builder.getEnableCompression))
+
+        self.add(pyrogue.LocalVariable(
+            name='Bz2WorkFactor',
+            description='Sets the BZ Work factor of the bzip compression',
+            mode='RW',
+            value=bz2_work_factor,
+            localSet=lambda value: self.builder.setBz2WorkFactor(value),
+            localGet=self.builder.getBz2WorkFactor))
+
+        self.add(pyrogue.LocalVariable(
+            name='FlacLevel',
+            description='Sets the algorithm used to compress the time fields of all timestreams',
+            mode='RW',
+            value=flac_level,
+            localSet=lambda value: self.builder.setFlacLevel(value),
+            localGet=self.builder.getFlacLevel))
 
         self.add(pyrogue.LocalVariable(
             name='AggTime',

--- a/python/sosmurf/util.py
+++ b/python/sosmurf/util.py
@@ -142,6 +142,12 @@ class VariableGroups:
             data = yaml.safe_load(f)
         return cls(data)
 
+    def update(self, vgs):
+        """
+        Updates data dict with that of another VariableGroups object
+        """
+        self.data.update(vgs.data)
+
     def template(self):
         def helper(data):
             rv = {}

--- a/scripts/stream.py
+++ b/scripts/stream.py
@@ -69,8 +69,8 @@ def main():
     pipe.Add(stream_root.builder)
     pipe.Add(sosmurf.SessionManager.SessionManager, stream_id=args.stream_id)
     # pipe.Add(sosmurf.util.stream_dumper)
-    pipe.Add(core.G3NetworkSender, hostname='*',
-             port=args.stream_port, max_queue_size=1000)
+    # pipe.Add(core.G3NetworkSender, hostname='*',
+    #          port=args.stream_port, max_queue_size=1000)
     pipe.Add(file_writer.rotator)
 
     vgs = None

--- a/scripts/stream.py
+++ b/scripts/stream.py
@@ -73,11 +73,15 @@ def main():
              port=args.stream_port, max_queue_size=1000)
     pipe.Add(file_writer.rotator)
 
-    meta_file = os.path.expandvars(cfg.get('meta_register_file'))
     vgs = None
-    if meta_file is not None:
-        print(f"Loading metadata registers from {meta_file}...")
-        vgs = sosmurf.util.VariableGroups.from_file(meta_file)
+    default_meta_file = '/usr/local/src/smurf-streamer/meta_registers.yaml'
+    meta_file = cfg.get('meta_register_file')
+    if os.path.exists(default_meta_file):
+        vgs = sosmurf.util.VariableGroups.from_file(default_meta_file)
+    if meta_file is not None and vgs is not None:
+        vgs.update(sosmurf.util.VariableGroups.from_file(
+            os.path.expandvars(meta_file)
+        ))
 
     pcie_kwargs = {
         'lane': args.pcie_rssi_lane, 'ip_addr': args.ip_addr,

--- a/scripts/stream.py
+++ b/scripts/stream.py
@@ -69,8 +69,8 @@ def main():
     pipe.Add(stream_root.builder)
     pipe.Add(sosmurf.SessionManager.SessionManager, stream_id=args.stream_id)
     # pipe.Add(sosmurf.util.stream_dumper)
-    # pipe.Add(core.G3NetworkSender, hostname='*',
-    #          port=args.stream_port, max_queue_size=1000)
+    pipe.Add(core.G3NetworkSender, hostname='*',
+             port=args.stream_port, max_queue_size=1000)
     pipe.Add(file_writer.rotator)
 
     vgs = None

--- a/src/SmurfBuilder.cpp
+++ b/src/SmurfBuilder.cpp
@@ -157,7 +157,7 @@ G3FramePtr SmurfBuilder::FrameFromSamples(
     tes_ts->SetDataFromBuffer((void*)tes_buffer, 2, tes_shape, NPY_INT32,
             std::pair<int,int>(0, nsamps));
     tes_ts->Options(
-        enable_compression_, flac_level_, bz2_work_factor_, data_encode_algo_,
+        enable_compression_, flac_level_, bz2_work_factor_, tes_bias_encode_algo_,
         time_encode_algo_
     );
 
@@ -165,7 +165,7 @@ G3FramePtr SmurfBuilder::FrameFromSamples(
     primary_ts->SetDataFromBuffer((void*)primary_buffer, 2, primary_shape,
             NPY_INT64, std::pair<int,int>(0, nsamps));
     primary_ts->Options(
-        enable_compression_, flac_level_, bz2_work_factor_, data_encode_algo_,
+        enable_compression_, flac_level_, bz2_work_factor_, primary_encode_algo_,
         time_encode_algo_
     );
 

--- a/src/SmurfBuilder.cpp
+++ b/src/SmurfBuilder.cpp
@@ -148,17 +148,26 @@ G3FramePtr SmurfBuilder::FrameFromSamples(
     data_ts->times = sample_times;
     data_ts->SetDataFromBuffer((void*)data_buffer, 2, data_shape, NPY_INT32,
             std::pair<int,int>(0, nsamps));
-    data_ts->Options(data_encode_algo_, time_encode_algo_);
+    data_ts->Options(
+        enable_compression_, flac_level_, bz2_work_factor_, data_encode_algo_,
+        time_encode_algo_
+    );
 
     tes_ts->times = G3VectorTime(sample_times);
     tes_ts->SetDataFromBuffer((void*)tes_buffer, 2, tes_shape, NPY_INT32,
             std::pair<int,int>(0, nsamps));
-    tes_ts->Options(tes_bias_encode_algo_, time_encode_algo_);
+    tes_ts->Options(
+        enable_compression_, flac_level_, bz2_work_factor_, data_encode_algo_,
+        time_encode_algo_
+    );
 
     primary_ts->times = G3VectorTime(sample_times);
     primary_ts->SetDataFromBuffer((void*)primary_buffer, 2, primary_shape,
             NPY_INT64, std::pair<int,int>(0, nsamps));
-    primary_ts->Options(primary_encode_algo_, time_encode_algo_);
+    primary_ts->Options(
+        enable_compression_, flac_level_, bz2_work_factor_, data_encode_algo_,
+        time_encode_algo_
+    );
 
     if (encode_timestreams_){
         data_ts->Encode();
@@ -303,6 +312,29 @@ int SmurfBuilder::getTimeEncodeAlgo() const{
     return time_encode_algo_;
 }
 
+int SmurfBuilder::getEnableCompression() const{
+    return enable_compression_;
+}
+
+void SmurfBuilder::setEnableCompression(int enable){
+    enable_compression_ = enable;
+}
+
+int SmurfBuilder::getBz2WorkFactor() const{
+    return bz2_work_factor_;
+}
+
+void SmurfBuilder::setBz2WorkFactor(int bz2_work_factor){
+    bz2_work_factor_ = bz2_work_factor;
+}
+
+int SmurfBuilder::getFlacLevel() const{
+    return flac_level_;
+}
+
+void SmurfBuilder::setFlacLevel(int flac_level){
+    flac_level_ = flac_level;
+}
 // Assist with testing the pure C++ interface
 static
 G3SuperTimestreamPtr test_cxx_interface(int nsamps, int first, int second)
@@ -347,6 +379,12 @@ void SmurfBuilder::setup_python(){
     .def("setTesBiasEncodeAlgo", &SmurfBuilder::setTesBiasEncodeAlgo)
     .def("getTimeEncodeAlgo", &SmurfBuilder::getTimeEncodeAlgo)
     .def("setTimeEncodeAlgo", &SmurfBuilder::setTimeEncodeAlgo)
+    .def("getEnableCompression", &SmurfBuilder::getEnableCompression)
+    .def("setEnableCompression", &SmurfBuilder::setEnableCompression)
+    .def("getBz2WorkFactor", &SmurfBuilder::getBz2WorkFactor)
+    .def("setBz2WorkFactor", &SmurfBuilder::setBz2WorkFactor)
+    .def("getFlacLevel", &SmurfBuilder::getFlacLevel)
+    .def("setFlacLevel", &SmurfBuilder::setFlacLevel)
     ;
     bp::def("build_g3super", test_cxx_interface);
 

--- a/src/SmurfBuilder.cpp
+++ b/src/SmurfBuilder.cpp
@@ -210,6 +210,17 @@ G3FramePtr SmurfBuilder::FrameFromSamples(
         printf(" - Copy Time: %ld ms\n", (frame_start - copy_start).count()/1000000);
         printf(" - Frame Time: %ld ms\n", (stop_time - frame_start).count()/1000000);
         printf("%lu elements in queue...\n", queue_.size());
+        printf(
+            "Encoding Options:\n"
+            " - enabled: %d\n"
+            " - data_algo: %d\n"
+            " - primary_algo: %d\n"
+            " - tes_algo: %d\n"
+            " - flac_level: %d\n"
+            " - BZ2_WorkFactor: %d\n",
+            enable_compression_, data_encode_algo_, primary_encode_algo_,
+            time_encode_algo_, flac_level_, bz2_work_factor_
+        );
     }
 
     return frame;

--- a/src/python.cpp
+++ b/src/python.cpp
@@ -1,13 +1,24 @@
 #include "SmurfTransmitter.h"
 #include "SmurfBuilder.h"
 
+#define PY_ARRAY_UNIQUE_SYMBOL Py_Array_API_SO3G
+#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+#include <numpy/arrayobject.h>
 namespace bp = boost::python;
 
+static void* _sosmurf_import_array() {
+    import_array();
+    return NULL;
+}
+
 BOOST_PYTHON_MODULE(sosmurfcore){
+    // _so3g_import_array();
+    
     bp::import("rogue");
     bp::import("spt3g.core");
 
     PyEval_InitThreads();
+    _sosmurf_import_array();
 
     SmurfTransmitter::setup_python();
     SmurfBuilder::setup_python();

--- a/src/python.cpp
+++ b/src/python.cpp
@@ -1,9 +1,7 @@
 #include "SmurfTransmitter.h"
 #include "SmurfBuilder.h"
+#include "so3g_numpy.h"
 
-#define PY_ARRAY_UNIQUE_SYMBOL Py_Array_API_SO3G
-#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
-#include <numpy/arrayobject.h>
 namespace bp = boost::python;
 
 static void* _sosmurf_import_array() {

--- a/src/python.cpp
+++ b/src/python.cpp
@@ -12,8 +12,6 @@ static void* _sosmurf_import_array() {
 }
 
 BOOST_PYTHON_MODULE(sosmurfcore){
-    // _so3g_import_array();
-    
     bp::import("rogue");
     bp::import("spt3g.core");
 


### PR DESCRIPTION
The v0.3.0 update improves performance and adds some new features that we've found to be necessary when working with one or more UFM's, all of which are detailed below.

This will be released simultaneously with sodetlib version v0.3.0 which includes a new version of sotodlib required to load the super-timestream format. Make sure you're upgrading both of these dockers simultaneously or else loading data will not work!

# Updates
## G3SuperTimestream
The biggest update in this version is the switch of the base data format from the G3TimestreamMap to [G3SuperTimestream](https://github.com/simonsobs/so3g/pull/98), which has the benefits of:
1. Being able to store 32 bit data, halving the size of G3 files
2. Being able to compress data with FLAC and BZIP, allowing us to reduce file-sizes by another factor of ~3 or so
3. General improved performance, see Matthew's PR or the so3g docs for more details

New rogue variables were added to control compression behavior:
 - `EnableCompression`: Enables compression on serialization
 - `FlacLevel`: Sets the flac level used
 - `Bz2WorkFactor`: Sets the Bz2 work factor used by bzip
 - `DataEncodeAlgo`: Sets which compression algorithms are used on detector data
 - `PrimaryEncodeAlgo`: Sets which compression algorithms are used on Primary data
 - `TesBiasEncodeAlgo`: Sets which compression algorithms are used on TES Bias data
 - `TimeEncodeAlgo`: Sets which compression algorithms are used on timestamps
 - `BuilderEncode`: Sets whether encoding occurs in the builder (as opposed to when frames are written to disk)
Most of these people shouldn't really need to touch.

## Default Meta-vars

A up-to-date meta_registers.yaml is now built into the docker and loaded by default. If a meta_registers file is specified in the sys-config, it will now update the values of the default. This way users don't also need to make sure their meta registers file is up-to-date along with the streamer version. 

## Publishing metadata of completed files
When a G3File is completed, a message is now published via the Pysmurf Publisher which can be processed by the pysmurf-monitor, allowing G3-Files to be handled by the SupRsync agent

## open_g3stream register
An additional Rogue register called `open_g3stream`  has been added that will tell the SessionManager to begin a new streaming session. This will allow us to stream data without relying on pysmurf's ` FileWriter.IsOpen` register, which is only set when .dat files are being written, and allows us to stream g3 data without streaming to .dat. 

## Performance and Structural Improvements

Improved the structure of  the Smurf-Builder's FlushStash function so that we can be sure it is only being called by a single thread.  Also added compiler optimization which greatly improves Builder performance.

