### PR TITLE
Obs end frame

### DIFF
--- a/python/sosmurf/SessionManager.py
+++ b/python/sosmurf/SessionManager.py
@@ -63,9 +63,8 @@ class SessionManager:
 
     def start_session(self):
         self.session_id = int(time.time())
-
         frame = core.G3Frame(core.G3FrameType.Observation)
-
+        frame['location'] = 'start'
         self.tag_frame(frame)
         return frame
 
@@ -80,6 +79,12 @@ class SessionManager:
             if self.end_session_flag:
                 # Returns [previous, end, obs cleanse, wiring cleanse]
                 out = []
+
+                end_session_frame = core.G3Frame(core.G3FrameType.Observation)
+                end_session_frame['location'] = 'end'
+                self.tag_frame(end_session_frame)
+
+                out.append(end_session_frame)
                 out.append(self.flowcontrol_frame(FlowControl.END))
 
                 f = core.G3Frame(core.G3FrameType.Observation)

--- a/python/sosmurf/SessionManager.py
+++ b/python/sosmurf/SessionManager.py
@@ -64,7 +64,7 @@ class SessionManager:
     def start_session(self):
         self.session_id = int(time.time())
         frame = core.G3Frame(core.G3FrameType.Observation)
-        frame['location'] = 'start'
+        frame['stream_placement'] = 'start'
         self.tag_frame(frame)
         return frame
 
@@ -81,7 +81,7 @@ class SessionManager:
                 out = []
 
                 end_session_frame = core.G3Frame(core.G3FrameType.Observation)
-                end_session_frame['location'] = 'end'
+                end_session_frame['stream_placement'] = 'end'
                 self.tag_frame(end_session_frame)
 
                 out.append(end_session_frame)


### PR DESCRIPTION
Adds Observation frames to signal the end of an observation.

This adds the key `stream_placement` to Observation frames, which can be either "start" or "end"