### PR TITLE
Adds size-cap for Builder queue and adds rogue var to monitor dropped frames in the builder.

### DIFF
--- a/docker/spt3g-pysmurf-server-base/Dockerfile
+++ b/docker/spt3g-pysmurf-server-base/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update --fix-missing \
         libbz2-dev \
     && rm -rf /var/lib/apt/lists/*
 
-RUN git clone https://github.com/CMB-S4/spt3g_software.git
+RUN git clone https://github.com/CMB-S4/spt3g_software.git && cd spt3g_software && git checkout  5f30121395129de9c9a6af2976de8ba8e876b5a8
 
 RUN cd spt3g_software \
       && mkdir -p build \

--- a/include/SmurfBuilder.h
+++ b/include/SmurfBuilder.h
@@ -11,6 +11,10 @@
 
 #define MAX_DATASOURCE_QUEUE_SIZE 3000
 
+// Maximum total size of the write queue (channels * samples)
+// Memory usage should be capped to around a few GB
+#define MAX_BUILDER_QUEUE_SIZE 100000000
+
 // Flow control constants
 #define FC_ALIVE   0
 #define FC_START   1
@@ -59,6 +63,8 @@ public:
     void setFlacLevel(int flac_level);
     int getFlacLevel() const;
 
+    size_t getDroppedPackets();
+
 protected:
     void ProcessNewData();
 
@@ -91,6 +97,8 @@ private:
     int enable_compression_;
     int bz2_work_factor_;
     int flac_level_;
+    size_t queue_size_;
+    size_t dropped_packets_;
 
     bool running_;
     bool debug_;

--- a/include/SmurfBuilder.h
+++ b/include/SmurfBuilder.h
@@ -13,7 +13,7 @@
 
 // Maximum total size of the write queue (channels * samples)
 // Memory usage should be capped to around a few GB
-#define MAX_BUILDER_QUEUE_SIZE 100000000
+#define MAX_BUILDER_QUEUE_SIZE 50000000
 
 // Flow control constants
 #define FC_ALIVE   0
@@ -63,7 +63,7 @@ public:
     void setFlacLevel(int flac_level);
     int getFlacLevel() const;
 
-    size_t getDroppedPackets();
+    size_t getDroppedFrames();
 
 protected:
     void ProcessNewData();
@@ -98,7 +98,7 @@ private:
     int bz2_work_factor_;
     int flac_level_;
     size_t queue_size_;
-    size_t dropped_packets_;
+    size_t dropped_frames_;
 
     bool running_;
     bool debug_;

--- a/include/SmurfSample.h
+++ b/include/SmurfSample.h
@@ -22,7 +22,6 @@ public:
         G3FrameObject(), time_(time), status_(status){}
 
     std::string status_;
-
     G3Time time_;
 
     static void setup_python() {};

--- a/python/sosmurf/StreamBase/_StreamBase.py
+++ b/python/sosmurf/StreamBase/_StreamBase.py
@@ -183,6 +183,14 @@ class StreamBase(pyrogue.Device):
             value=0,
         ))
 
+        self.add(pyrogue.LocalVariable(
+            name="DroppedFrames",
+            description="Number of frames dropped by the ",
+            mode='RO',
+            value=0,
+            localGet=self.builder.getDroppedFrames
+        ))
+
     def getDataChannel(self):
         return self._transmitter.getDataChannel()
 

--- a/scripts/emulate.py
+++ b/scripts/emulate.py
@@ -31,7 +31,6 @@ def main():
     pipe = core.G3Pipeline()
     pipe.Add(stream_root.builder)
     pipe.Add(sosmurf.SessionManager.SessionManager, stream_id=args.stream_id)
-    pipe.Add(sosmurf.util.stream_dumper)
     pipe.Add(core.G3NetworkSender,
         hostname='*', port=args.stream_port, max_queue_size=1000
     )

--- a/scripts/test_client.py
+++ b/scripts/test_client.py
@@ -1,6 +1,9 @@
 #%% Imports
 from pysmurf.client.base.smurf_control import SmurfControl
 import os
+import numpy as np
+import sodetlib as sdl
+from tqdm import tqdm, trange
 
 #%%
 class Registers:
@@ -29,7 +32,7 @@ def set_reg(S: SmurfControl, reg, val):
 
 def get_reg(S: SmurfControl, reg):
     _reg = ':'.join([S._epics_root, reg])
-    return S._caget(_reg)
+    return S._caget(_reg, use_monitor=False)
 
 #%%
 
@@ -41,6 +44,20 @@ os.makedirs('/data/smurf_data/status', exist_ok=True)
 S = SmurfControl(epics_root=epics_root, cfg_file=cfg_file)
 
 #%%
-set_reg(S, Registers.debug_data, 1)
+set_reg(S, Registers.debug_builder, 1)
+
+#%%
+S.set_channel_mask(np.arange(2000))
+#%%
+S.set_stream_data_source_period(1e-6)
+#%%
+sdl.stream_g3_on(S, emulator=True)
+#%%
+S.set_postdata_emulator_type('Noise')
+
+#%%
+from epics import caget, caput
+#%%
+set_reg(S, Registers.agg_time, 10)
+    
 # %%
-get_reg(S, Registers.debug_data)


### PR DESCRIPTION
After investigating crashes on smurf-srv20 in P10R1, I found that segfaults in the streamer (see https://github.com/simonsobs/smurf-streamer/issues/33 and https://github.com/simonsobs/sodetlib/issues/273) are caused by not having a max queue size on the data buffer in the SmurfBuilder module. If the time it takes to save the G3Frame is larger than the aggregation time of the G3Frame, this can start a data pile-up that eventually causes this to crash.

This PR adds a max size to that queue, and will drop frames when it is reached. The number of frames dropped can be monitored using the Rogue var `smurf_server_s<slot>:AMCc:SmurfProcessor:SOStream:DroppedFrames`. I've tested this with data rates that have previously crashed the streamer (like flux-ramp rates of 30kHz and 4096 channels) and it seems to work, though it still slows down rogue communication as the GIL is held to build the SuperTimestream.

I'm still not sure why frame build times take so much longer on some smurf-servers than they do on my local system I used for testing.