### PR TITLE
Compression debugging

### DIFF
--- a/include/SmurfBuilder.h
+++ b/include/SmurfBuilder.h
@@ -63,6 +63,9 @@ public:
     void setFlacLevel(int flac_level);
     int getFlacLevel() const;
 
+    float getFrameBuildTime();
+    float getCompressionTime();
+
     size_t getDroppedFrames();
 
 protected:
@@ -103,6 +106,10 @@ private:
     bool running_;
     bool debug_;
     bool encode_timestreams_;
+
+    // Frame Write durations for monitoring
+    float compression_time_;
+    float frame_build_time_;
 
     std::thread process_stash_thread_;
 

--- a/meta_registers.yaml
+++ b/meta_registers.yaml
@@ -74,9 +74,11 @@ root.SmurfProcessor:
         Tau: 1
         Theta: 1
     SOStream:
-        dataDropCnt: 3
-        metaDropCnt: 3
+        TransmitterDataDropCnt: 2
+        TransmitterMetaDropCnt: 2
         pysmurf_action: 3
         pysmurf_action_timestamp: 3
         stream_tag: 3
         open_g3stream: 3
+        FrameBuildTime: 2
+        CompressionTime: 2

--- a/python/sosmurf/StreamBase/_StreamBase.py
+++ b/python/sosmurf/StreamBase/_StreamBase.py
@@ -191,6 +191,22 @@ class StreamBase(pyrogue.Device):
             localGet=self.builder.getDroppedFrames
         ))
 
+        self.add(pyrogue.LocalVariable(
+            name="CompressionTime",
+            description="Time taken (ms) to compress the latest G3 Data",
+            mode='RO',
+            value=0.0,
+            localGet=self.builder.getCompressionTime
+        ))
+
+        self.add(pyrogue.LocalVariable(
+            name="FrameBuildTime",
+            description="Time taken (ms) to build the latest G3Frame",
+            mode='RO',
+            value=0.0,
+            localGet=self.builder.getFrameBuildTime
+        ))
+
     def getDataChannel(self):
         return self._transmitter.getDataChannel()
 

--- a/src/SmurfBuilder.cpp
+++ b/src/SmurfBuilder.cpp
@@ -153,26 +153,34 @@ G3FramePtr SmurfBuilder::FrameFromSamples(
     data_ts->times = sample_times;
     data_ts->SetDataFromBuffer((void*)data_buffer, 2, data_shape, NPY_INT32,
             std::pair<int,int>(0, nsamps));
-    data_ts->Options(
-        enable_compression_, flac_level_, bz2_work_factor_, data_encode_algo_,
-        time_encode_algo_
-    );
 
     tes_ts->times = G3VectorTime(sample_times);
     tes_ts->SetDataFromBuffer((void*)tes_buffer, 2, tes_shape, NPY_INT32,
             std::pair<int,int>(0, nsamps));
-    tes_ts->Options(
-        enable_compression_, flac_level_, bz2_work_factor_, tes_bias_encode_algo_,
-        time_encode_algo_
-    );
 
     primary_ts->times = G3VectorTime(sample_times);
     primary_ts->SetDataFromBuffer((void*)primary_buffer, 2, primary_shape,
             NPY_INT64, std::pair<int,int>(0, nsamps));
-    primary_ts->Options(
-        enable_compression_, flac_level_, bz2_work_factor_, primary_encode_algo_,
-        time_encode_algo_
-    );
+
+    if (enable_compression_){
+        data_ts->Options(
+            enable_compression_, flac_level_, bz2_work_factor_, data_encode_algo_,
+            time_encode_algo_
+        );
+        tes_ts->Options(
+            enable_compression_, flac_level_, bz2_work_factor_, tes_bias_encode_algo_,
+            time_encode_algo_
+        );
+        primary_ts->Options(
+            enable_compression_, flac_level_, bz2_work_factor_, primary_encode_algo_,
+            time_encode_algo_
+        );
+    }
+    else{
+        data_ts->Options(enable_compression_, -1, -1, -1, -1);
+        tes_ts->Options(enable_compression_, -1, -1, -1, -1);
+        primary_ts->Options(enable_compression_, -1, -1, -1, -1);
+    }
 
     compression_start = std::chrono::system_clock::now();
 


### PR DESCRIPTION
Solves some compression issues noticed in P10R2:
- Fixes the `enable_compression` variable so it works properly
- Adds `compression_time` and `frame_build_time` as rogue variables which can be monitored in grafana