### PR TITLE
Fix for build and push workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,7 @@ jobs:
 
           echo "${REGISTRY_PASSWORD}" | docker login -u "${REGISTRY_USER}" --password-stdin
 
-          docker-compose build
+          docker compose build
 
           docker tag smurf-streamer:latest ${DOCKERHUB_ORG}/smurf-streamer:latest
           docker tag smurf-streamer:latest ${DOCKERHUB_ORG}/smurf-streamer:${DOCKER_TAG}


### PR DESCRIPTION
Change `docker-compose` to `docker compose` in the build-and-push workflow.