### PR TITLE
Hold the GIL across FlushStash frame teardown (fixes ProcessStashThread segfault)

### DIFF
--- a/src/SmurfBuilder.cpp
+++ b/src/SmurfBuilder.cpp
@@ -264,11 +264,24 @@ void SmurfBuilder::FlushStash(){
         queue_size_ = 0;
     }
 
+    // Hold the GIL for the remainder of this method. FlushStash() runs on
+    // process_stash_thread_, a bare std::thread with no Python thread state, yet
+    // everything below builds, emits, and destroys G3Frames whose members are
+    // Boost.Python-wrapped objects (G3SuperTimestream backed by NumPy arrays).
+    // Dropping the last reference to such an object without the GIL races
+    // CPython's GC/allocator and segfaults (typically in PyObject_GC_Del during
+    // teardown). The GIL is acquired *after* the stash swap above so it never
+    // overlaps read_stash_lock_/write_stash_lock_. FrameFromSamples() nests its
+    // own PyGILState_Ensure/Release, which is safe (and now redundant) under
+    // this outer hold.
+    PyGILState_STATE gstate = PyGILState_Ensure();
+
     if (read_stash_.empty()){
         G3FramePtr frame = boost::make_shared<G3Frame>();
         frame->Put("sostream_flowcontrol", boost::make_shared<G3Int>(FC_ALIVE));
         frame->Put("time", boost::make_shared<G3Time>(G3Time::Now()));
         FrameOut(frame);
+        PyGILState_Release(gstate);
         return;
     }
 
@@ -290,6 +303,8 @@ void SmurfBuilder::FlushStash(){
         }
     }
     read_stash_.clear();
+
+    PyGILState_Release(gstate);
 }
 
 void SmurfBuilder::ProcessNewData(){


### PR DESCRIPTION
## Summary

`SmurfBuilder::FlushStash()` runs on `process_stash_thread_` — a native `std::thread`
created in the constructor with no Python thread state — yet it builds, emits, and
destroys `G3Frame`s whose members are Boost.Python-wrapped objects
(`G3SuperTimestream` backed by NumPy arrays). When the last reference to such an
object is dropped on this thread **without the GIL**, CPython's GC/allocator is
mutated concurrently with the interpreter and the process segfaults during teardown.

This was reported in the field as an intermittent streamer crash (the process just
exits). The coredump backtrace:

```
#0  PyObject_GC_Del ()
#1  ?? ()
#2  boost::python::converter::shared_ptr_deleter::operator()()
#3  sp_counted_impl_pd<void*, shared_ptr_deleter>::dispose()         [spt3g _libcore.so]
#4  sp_counted_base::release()                                       [sosmurfcore.so]
#5  sp_counted_impl_pd<G3Frame*, sp_ms_deleter<G3Frame>>::dispose()  [sosmurfcore.so]
#6  sp_counted_base::release()                                       [sosmurfcore.so]
#7  SmurfBuilder::FlushStash()                                       [sosmurfcore.so]
#8  SmurfBuilder::ProcessStashThread()                               [sosmurfcore.so]
```

`error 4` (user-mode read of an unmapped page) at a GC-list pointer is consistent with
a stale `gc_next/gc_prev` from an unsynchronized GC-list mutation.

## Why it surfaces now

The defect is latent. The only window in `FlushStash` that held the GIL was inside
`FrameFromSamples()` (≈ lines 155–203), covering the NumPy/compression work but **not**
frame construction, emission via `FrameOut()`, or `read_stash_.clear()`. On older
CPython the unprotected GC-list manipulation usually got away with it; **Python 3.12
reworked the GC internals** that `PyObject_GC_Del` touches, so the same violation now
hard-faults. It is seen under CPU saturation (e.g. all slots running analysis), where
heavy GIL churn widens the race window.

## Fix

Hold the GIL for the remainder of `FlushStash()`:

- Acquire `PyGILState_Ensure()` **after** the stash swap, so it never overlaps
  `read_stash_lock_` / `write_stash_lock_` (no lock-ordering hazard — `ProcessNewData`
  takes `write_stash_lock_` but never waits on the GIL).
- Release on both exit paths (the empty-stash early `return` and the normal end).
- `FrameFromSamples()` keeps its own nested `PyGILState_Ensure/Release`, which is safe
  (and now redundant) under this outer hold.

The expensive NumPy/compression work already ran under the GIL, so the added
contention is limited to cheap frame construction / emission / teardown.

## Validation

Reproduced the exact teardown race in a minimal harness that stashes **real**
`so3g.G3SuperTimestream` (NumPy-backed) objects inside real `spt3g.core.G3Frame`s and
destroys them on a bare `std::thread` (a stand-in for `ProcessStashThread`):

| Worker thread | Result |
| --- | --- |
| destroys frames **without** the GIL | **SIGSEGV** (reproducible) |
| destroys frames **holding** the GIL  | clean |

Same boost::python G3-object-lifecycle race as the field coredump; the GIL is the only
variable. This patch applies that GIL-held pattern to the real teardown path.

## Notes

- Targeted at `tpm/rogue6`. The `SmurfBuilder.cpp` crash site is byte-identical to
  `master`, so this fix applies equally there if desired.
- C++-only change; no change to frame contents or pipeline behavior.
